### PR TITLE
Added an "Events" planning feature. 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ PGPORT=5432
 #PGHOST=localhost
 #PGPORT=50433
 
+# an IANA TZ code https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+TZ=America/Chicago
+
 SESSION_SECRET=
 
 # Google OAuth details

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 AS dev
+FROM node:14 AS dev
 WORKDIR /usr/src/app
 
 ENV NODE_ENV=development

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       "dev": true
     },
     "@popperjs/core": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.1.tgz",
-      "integrity": "sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
     },
     "@prisma/client": {
       "version": "2.19.0",
@@ -4463,9 +4463,9 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "sheodox-ui": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sheodox-ui/-/sheodox-ui-0.4.2.tgz",
-      "integrity": "sha512-s4g1QhSjTHGD840545KS+dOYn8CaJ86u6OUqzPNdCkJrMZofLafa+hhydGjelUUtqFDv5jzkbtmJlSjtN4n+ZQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/sheodox-ui/-/sheodox-ui-0.5.0.tgz",
+      "integrity": "sha512-HLOIJtJCjYKhU2tpYvyhIHGFxGoP+075NgBnpC6sDn7J1tVV8tmLM7mlNnuHmeUb+lXQ5Uq76h/kZHmW1YWDZA==",
       "requires": {
         "@popperjs/core": "^2.9.1",
         "normalize.css": "^8.0.1"
@@ -5766,9 +5766,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "serialize-javascript": "^5.0.1",
     "serve-favicon": "^2.5.0",
     "sharp": "^0.24.0",
-    "sheodox-ui": "^0.4.2",
+    "sheodox-ui": "^0.5.0",
     "socket.io": "^4.0.0",
     "socket.io-client": "^4.0.0",
     "style-loader": "^2.0.0",

--- a/prisma/migrations/20210407002231_events/migration.sql
+++ b/prisma/migrations/20210407002231_events/migration.sql
@@ -1,0 +1,66 @@
+-- AlterTable
+ALTER TABLE "Candidate" ALTER COLUMN "notes" SET DEFAULT E'';
+
+-- CreateTable
+CREATE TABLE "Event" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "notes" TEXT NOT NULL DEFAULT E'',
+    "attendanceType" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "creatorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Rsvp" (
+    "id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "notes" TEXT NOT NULL DEFAULT E'',
+    "userId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RsvpDay" (
+    "id" TEXT NOT NULL,
+    "date" TEXT NOT NULL,
+    "stayingOvernight" BOOLEAN NOT NULL,
+    "userId" TEXT NOT NULL,
+    "rsvpId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Rsvp.eventId_userId_unique" ON "Rsvp"("eventId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RsvpDay.eventId_userId_date_unique" ON "RsvpDay"("eventId", "userId", "date");
+
+-- CreateIndex
+CREATE INDEX "RsvpDay.eventId_date_index" ON "RsvpDay"("eventId", "date");
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Rsvp" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Rsvp" ADD FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RsvpDay" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RsvpDay" ADD FOREIGN KEY ("rsvpId") REFERENCES "Rsvp"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RsvpDay" ADD FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,9 @@ model User {
   bookerAssignment BookerAssignment[]
   createdAt        DateTime           @default(now())
   lastActiveAt     DateTime           @default(now())
+  rsvps            Rsvp[]
+  events           Event[]
+  rsvpDays         RsvpDay[]
 }
 
 model Image {
@@ -74,7 +77,7 @@ model Race {
 model Candidate {
   id        String           @id @default(uuid())
   name      String
-  notes     String
+  notes     String           @default("")
   votes     Vote[]
   creatorId String
   raceId    String
@@ -133,4 +136,46 @@ model BookerAssignment {
   createdAt DateTime   @default(now())
 
   @@unique([concern, userId])
+}
+
+model Event {
+  id             String    @id @default(uuid())
+  name           String
+  notes          String    @default("")
+  attendanceType String
+  startDate      DateTime
+  endDate        DateTime
+  creatorId      String
+  creator        User      @relation(fields: [creatorId], references: [id])
+  createdAt      DateTime  @default(now())
+  rsvps          Rsvp[]
+  rsvpDays       RsvpDay[]
+}
+
+model Rsvp {
+  id       String    @id @default(uuid())
+  status   String
+  notes    String    @default("")
+  userId   String
+  user     User      @relation(fields: [userId], references: [id])
+  eventId  String
+  event    Event     @relation(fields: [eventId], references: [id])
+  rsvpDays RsvpDay[]
+
+  @@unique([eventId, userId])
+}
+
+model RsvpDay {
+  id               String  @id @default(uuid())
+  date             String
+  stayingOvernight Boolean
+  userId           String
+  user             User    @relation(fields: [userId], references: [id])
+  rsvpId           String
+  rsvp             Rsvp    @relation(fields: [rsvpId], references: [id])
+  eventId          String
+  event            Event   @relation(fields: [eventId], references: [id])
+
+  @@unique([eventId, userId, date])
+  @@index([eventId, date])
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -27,6 +27,7 @@ const app = express(),
     settings = require('./routes/settings'),
     voter = require('./routes/voter'),
     admin = require('./routes/admin'),
+    events = require('./routes/events'),
     images = require('./routes/images'),
     bodySizeLimit = '15mb';
 
@@ -87,6 +88,7 @@ app.use(initEchoRouter(io));
 app.use(voter(io));
 settings(io);
 app.use(admin(io));
+events(io);
 app.use(images);
 app.use(require('./routes'));
 

--- a/src/server/db/booker.ts
+++ b/src/server/db/booker.ts
@@ -200,4 +200,10 @@ export const voterBooker = new Booker('voter', [
     'add_candidate',
     'add_image',
     'remove_image'
+]);
+
+export const eventsBooker = new Booker('events', [
+    'view',
+    'organize',
+    'rsvp',
 ])

--- a/src/server/db/events.ts
+++ b/src/server/db/events.ts
@@ -1,0 +1,249 @@
+import Ajv from 'ajv';
+import {Event, Rsvp, RsvpDay} from '@prisma/client';
+import {prisma} from "./prisma";
+import {name as validName} from "../util/validator";
+const ajv = new Ajv(),
+    rsvpStatuses = ['going', 'not-going', 'maybe'] as const,
+    validateEventEditable = ajv.compile({
+        type: 'object',
+        properties: {
+            name: {type: 'string'},
+            attendanceType: {enum: ['real', 'virtual']},
+            notes: {type: 'string'},
+            startDate: {type: 'number'},
+            endDate: {type: 'number'},
+        },
+        additionalProperties: false
+    }),
+    validateRSPVStatus = ajv.compile({
+        enum: rsvpStatuses
+    }),
+    DAY_MS = 1000 * 60 * 60 * 24;
+
+export type RSVPStatus = typeof rsvpStatuses[number];
+type EventEditable = Pick<Event, 'name' | 'notes' | 'attendanceType' | 'startDate' | 'endDate'>
+export interface EventDay {
+    date: string, //date.toLocaleDateString()
+    dayOfWeek: number, //date.getDay()
+}
+interface RSVPSurveyDay {
+    date: string, // should be a date from an EventDay, given back
+    going: boolean,
+    stayingOvernight: boolean,
+}
+interface RSVPSurvey {
+    notes: string,
+    days?: RSVPSurveyDay[]
+}
+
+export type EventList = (Event & {rsvps: (Rsvp & {rsvpDays: RsvpDay[]})[]})[]
+
+function createRSVPDayValidator(eventDays: EventDay[]) {
+    return ajv.compile({
+        type: 'array',
+        items: {
+            type: 'object',
+            properties: {
+                date: {enum: eventDays.map(day => day.date)},
+                going: {type: 'boolean'},
+                stayingOvernight: {type: 'boolean'},
+            }
+        }
+    });
+}
+
+export function getEventDays(event: Pick<Event, 'startDate' | 'endDate'>) {
+    function getStartOfDay(date: Date) {
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    }
+
+    function toEventDay(date: Date) {
+        return {
+            date: date.toLocaleDateString(),
+            dayOfWeek: date.getDay()
+        };
+    }
+
+    const days: EventDay[] = [toEventDay(getStartOfDay(event.startDate))],
+        endTime = getStartOfDay(event.endDate).getTime();
+
+    let dayDuringEvent = getStartOfDay(event.startDate).getTime() + DAY_MS;
+    while (dayDuringEvent <= endTime) {
+        days.push(toEventDay(getStartOfDay(new Date(dayDuringEvent))));
+        dayDuringEvent += DAY_MS
+    }
+
+    return days;
+}
+
+function getMissingDays(oldDays: EventDay[], newDays: EventDay[]) {
+    return oldDays.filter(({date}) => {
+        return !newDays.some(newDay => newDay.date === date);
+    }).map(({date}) => date);
+}
+
+class Events {
+    constructor() {}
+
+    async list(): Promise<EventList> {
+        return await prisma.event.findMany({
+            orderBy: {
+                startDate: 'desc'
+            },
+            include: {
+                rsvps: {
+                    include: {
+                        rsvpDays: true
+                    }
+                },
+            }
+        });
+    }
+
+    validateEventData(data: EventEditable) {
+        if (!validateEventEditable(data)) {
+            return {error: 'Invalid data!'}
+        }
+
+        if (!validName(data.name)) {
+            return {error: 'Invalid name.'};
+        }
+
+        if (data.startDate > data.endDate) {
+            return {error: 'Start date must be before the end date.'}
+        }
+        return false;
+    }
+
+    async createEvent(userId: string, data: EventEditable) {
+        const validationErrors = this.validateEventData(data);
+        if (validationErrors) {
+            return validationErrors;
+        }
+
+        data.startDate = new Date(data.startDate);
+        data.endDate = new Date(data.endDate);
+        return await prisma.event.create({
+            data: {
+                ...data,
+                creatorId: userId
+            },
+            select: {
+                id: true
+            }
+        })
+    }
+    async deleteEvent(eventId: string) {
+        const whereEventId = {where: {eventId}};
+        await prisma.$transaction([
+            prisma.rsvpDay.deleteMany(whereEventId),
+            prisma.rsvp.deleteMany(whereEventId),
+            prisma.event.deleteMany({where: {id: eventId}})
+        ])
+    }
+    async updateEvent(eventId: string, data: EventEditable) {
+        const validationErrors = this.validateEventData(data);
+        if (validationErrors) {
+            return validationErrors;
+        }
+
+        data.startDate = new Date(data.startDate);
+        data.endDate = new Date(data.endDate);
+
+        const currentEvent = await prisma.event.findUnique({where: {id: eventId}}),
+            existingDays = getEventDays(currentEvent),
+            newDays = getEventDays(data),
+            noLongerApplicableDays = getMissingDays(existingDays, newDays);
+
+        await prisma.rsvpDay.deleteMany({
+            where: {
+                id: eventId,
+                date: {
+                    in: noLongerApplicableDays
+                }
+            }
+        });
+
+        return await prisma.event.update({
+            where: {id: eventId},
+            data,
+            select: {
+                id: true
+            }
+        })
+    }
+    async rsvp(userId: string, eventId: string, status: RSVPStatus, rsvpSurvey: RSVPSurvey) {
+        if (!validateRSPVStatus(status)) {
+            return {error: 'Invalid RSVP status!'}
+        }
+        const event = await prisma.event.findUnique({where: {id: eventId}});
+
+        if (!event) {
+            return {error: `Couldn't find that event!`};
+        }
+
+        //validate that all the days they're responding to are applicable for the days this event is held
+        const surveyDayValidator = createRSVPDayValidator(
+                getEventDays(event)
+            ),
+            validSurveyDays = status !== 'going' || surveyDayValidator(rsvpSurvey.days);
+
+        if (!validSurveyDays) {
+            return {error: 'Invalid survey response!'}
+        }
+
+        const relevantRspvResponse = {
+            status,
+            notes: rsvpSurvey.notes
+        }
+
+        //RSVPs are saved in two pieces, an RSVP which includes general information, like if they're going or not
+        //and any notes for the organizer. the second piece is one or more "RSVPDays" which are individual rows
+        //for each day during an event, showing which days they're going for a multiple day event
+        const rsvp = await prisma.rsvp.upsert({
+            where: {
+                eventId_userId: {eventId, userId}
+            },
+            create: {
+                eventId,
+                userId,
+                ...relevantRspvResponse
+            },
+            update: relevantRspvResponse
+        });
+
+        //delete the record of all days where the user may have said they were going, so if
+        //they changed their mind after saying they're going they will not show up as going anywhere.
+        //if they're going these will be replaced anyway
+        await prisma.rsvpDay.deleteMany({
+            where: {
+                eventId, userId
+            }
+        });
+
+        if (status === 'going') {
+            //'rsvpSurvey.days' is validated, but not with 'additionalProperties: false'
+            //so we need to be careful not to use object spread when putting this into
+            //the database (front end builds these based on EventDays[], which has
+            //additional properties we don't care about here
+            const rsvpDayPromises = rsvpSurvey.days
+                .filter(({going}) => going)
+                .map(rsvpDay => {
+                    return prisma.rsvpDay.create({
+                        data: {
+                            eventId,
+                            userId,
+                            rsvpId: rsvp.id,
+                            date: rsvpDay.date,
+                            stayingOvernight: rsvpDay.stayingOvernight
+                        }
+                    })
+                });
+
+            await prisma.$transaction(rsvpDayPromises);
+        }
+        return rsvp;
+    }
+}
+
+export const events = new Events();

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -5,7 +5,7 @@ import {users} from "../db/users";
 import {isReqSuperUser, isUserSuperUser} from '../util/superuser'
 import {AppRequest} from "../types";
 import {Server, Socket} from "socket.io";
-import {echoBooker, voterBooker} from "../db/booker";
+import {echoBooker, eventsBooker, voterBooker} from "../db/booker";
 import {Prisma} from '@prisma/client';
 import {SilverConduit} from "../util/silver-conduit";
 import {getManifest} from "../util/route-common";
@@ -16,7 +16,8 @@ import {adminLogger} from "../util/logger";
 const router = Router(),
     bookers = {
         echo: echoBooker,
-        voter: voterBooker
+        voter: voterBooker,
+        events: eventsBooker,
     };
 
 type BookerModule = keyof typeof bookers

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -1,0 +1,201 @@
+import {Server} from "socket.io";
+import {createSafeWebsocketHandler, SilverConduit} from "../util/silver-conduit";
+import {ToastOptions} from "../types";
+import {MaskedUser, users} from "../db/users";
+import {eventsBooker} from "../db/booker";
+import {eventsLogger} from "../util/logger";
+import {EventDay, EventList, events, getEventDays, RSVPStatus} from "../db/events";
+import {Event, Rsvp, RsvpDay} from "@prisma/client";
+import MarkdownIt from "markdown-it";
+const md = new MarkdownIt();
+
+function cloneObject<T>(obj: T): T {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+function pickProperties<Type, TProp extends keyof Type>(obj: Type, properties: TProp[]): Pick<Type, TProp> {
+    const picked: any = {}
+    for (const prop of properties)  {
+        picked[prop] = obj[prop];
+    }
+    return picked;
+}
+
+type MaskedRsvpDay = Pick<RsvpDay, 'date' | 'stayingOvernight'>
+interface MaskedRsvp extends Pick<Rsvp, 'status' | 'notes'> {
+    user: MaskedUser,
+    rsvpDays: MaskedRsvpDay[]
+}
+type RsvpStatusCounts = Record<RSVPStatus, number>;
+
+interface DayAttendee extends Pick<RsvpDay, 'stayingOvernight'> {
+    user: MaskedUser
+}
+
+interface MaskedEvent extends Omit<Event, 'creatorId' | 'startDate' | 'endDate'> {
+    creator: MaskedUser,
+    startDate: number,
+    endDate: number,
+    notesRendered: string,
+    userRsvp?: MaskedRsvp,
+    eventDays: EventDay[],
+    rsvpStatusCounts: RsvpStatusCounts,
+    attendeesByDay: (EventDay & {attendees: DayAttendee[]})[]
+}
+
+async function maskUser(userId: string) {
+    return (await users.getMasked([userId]))[0]
+}
+
+async function maskRsvp(rsvp: Rsvp & {rsvpDays: RsvpDay[]}) {
+    const rsvpDays: MaskedRsvpDay[] = [];
+
+    for (const day of rsvp.rsvpDays) {
+        rsvpDays.push({
+            ...pickProperties(day, ['date', 'stayingOvernight'])
+        })
+    }
+
+    return {
+        ...pickProperties(rsvp, ['status', 'notes']),
+        user: await maskUser(rsvp.userId),
+        rsvpDays,
+    }
+}
+
+async function maskEvent(list: EventList, userId: string): Promise<MaskedEvent[]> {
+    //don't let someone's permissions leak between users. otherwise notes will disappear
+    //with broadcasts if we blank out notes because a user doesn't have permission to view them
+    list = cloneObject(list);
+
+    const maskedEvents = [],
+        userCanOrganize = await eventsBooker.check(userId, 'organize');
+
+    for (const event of list) {
+        //cloning the object turns Date objects into strings, turn them back!
+        event.startDate = new Date(event.startDate);
+        event.endDate = new Date(event.endDate);
+
+        const rsvps: MaskedRsvp[] = [],
+            eventDays = getEventDays(event),
+            attendeesByDay = eventDays.map(day => {
+                return {
+                    ...day,
+                    attendees: []
+                }
+            });
+
+        for (const rsvp of event.rsvps) {
+            if (!userCanOrganize) {
+                rsvp.notes = '';
+            }
+            rsvps.push(await maskRsvp(rsvp));
+            const maskedUser = await maskUser(rsvp.userId);
+
+            for (const day of rsvp.rsvpDays) {
+                const eventDay = attendeesByDay.find(({date}) => date === day.date);
+                if (eventDay) {
+                    eventDay.attendees.push({
+                        ...pickProperties(day, ['stayingOvernight']),
+                        user: maskedUser
+                    });
+                }
+            }
+        }
+
+        const userRsvp = event.rsvps.find(rsvp => rsvp.userId === userId);
+
+        maskedEvents.push({
+            ...pickProperties(event, [
+                'id', 'notes', 'name', 'attendanceType', 'createdAt'
+            ]),
+            startDate: event.startDate.getTime(),
+            endDate: event.endDate.getTime(),
+            userRsvp: userRsvp ? await maskRsvp(userRsvp) : null,
+            creator: await maskUser(event.creatorId),
+            notesRendered: md.render(event.notes),
+            attendeesByDay,
+            eventDays,
+            rsvps,
+            rsvpStatusCounts: event.rsvps.reduce((counts, rsvp) => {
+                counts[rsvp.status as RSVPStatus] = (counts[rsvp.status as RSVPStatus] ?? 0) + 1
+                return counts;
+            }, {} as RsvpStatusCounts)
+        })
+    }
+    return maskedEvents;
+}
+
+module.exports = function(io: Server) {
+    const ioConduit = new SilverConduit(io, 'events'),
+        notificationConduit = new SilverConduit(io, 'notifications');
+
+    io.on('connection', async socket => {
+        const socketConduit = new SilverConduit(socket, 'events'),
+            singleUserNotifications = new SilverConduit(socket, 'notifications'),
+            userId = SilverConduit.getUserId(socket);
+
+        if (!userId) {
+            return;
+        }
+
+        async function broadcast() {
+            const eventData = await events.list()
+
+            ioConduit.filteredBroadcast('refresh', async userId => {
+                if (await eventsBooker.check(userId, 'view')) {
+                    return maskEvent(eventData, userId);
+                }
+            })
+        }
+
+        const user = await users.getUser(userId),
+            displayName = user.displayName,
+            checkPermission = createSafeWebsocketHandler(userId, eventsBooker, socket, eventsLogger);
+
+        const singleUserError = (message: string) => {
+            singleUserNotifications.emit('notification', {
+                variant: 'error',
+                title: 'Event Error',
+                message,
+            } as ToastOptions);
+        };
+
+        socketConduit.on({
+            init: checkPermission('view', async () => {
+                socketConduit.emit('refresh',
+                    await maskEvent(await events.list(), userId)
+                );
+            }),
+            createEvent: checkPermission('organize', async (data, done) => {
+                const event = await events.createEvent(userId, data);
+                if ('error' in event) {
+                    return singleUserError(event.error);
+                }
+
+                done(event.id);
+                broadcast();
+            }),
+            updateEvent: checkPermission('organize', async (id, data, done) => {
+                const event = await events.updateEvent(id, data);
+                if ('error' in event) {
+                    return singleUserError(event.error);
+                }
+
+                done(event.id);
+                broadcast();
+            }),
+            deleteEvent: checkPermission('organize', async (id) => {
+                await events.deleteEvent(id);
+            }),
+            rsvp: checkPermission('rsvp', async (eventId, status, rsvpSurvey) => {
+                const event = await events.rsvp(userId, eventId, status, rsvpSurvey);
+
+                if ('error' in event) {
+                    return singleUserError(event.error);
+                }
+                broadcast();
+            })
+        })
+    })
+}

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -1,6 +1,6 @@
 import {Router, Response} from 'express';
 import serializeJavascript from "serialize-javascript";
-import {voterBooker, echoBooker} from "../db/booker";
+import {voterBooker, echoBooker, eventsBooker} from "../db/booker";
 import {isReqSuperUser} from "../util/superuser";
 import {AppRequest} from "../types";
 import {getManifest} from "../util/route-common";
@@ -10,6 +10,7 @@ import {safeAsyncRoute} from "../util/error-handler";
 const router = Router();
 
 const overseerApps = {
+    events: 'Events',
     echo: 'Echo',
     voter: 'Voter',
 };
@@ -27,6 +28,7 @@ function entry(app?: string) {
             permissions = serializeJavascript({
                 voter: await voterBooker.getUserPermissions(id),
                 echo: await echoBooker.getUserPermissions(id),
+                events: await eventsBooker.getUserPermissions(id),
             }),
             links = [
                 {href: '/auth/logout', text: 'Logout', icon: 'sign-out-alt'}

--- a/src/server/util/logger.ts
+++ b/src/server/util/logger.ts
@@ -68,6 +68,7 @@ export const authLogger = createConcernLogger('auth');
 export const httpLogger = createConcernLogger('http');
 export const echoLogger = createConcernLogger('echo');
 export const voterLogger = createConcernLogger('voter');
+export const eventsLogger = createConcernLogger('events');
 export const adminLogger = createConcernLogger('admin');
 export const integrationsLogger = createConcernLogger('integrations');
 export const echoIntegrationLogger = createConcernLogger('echo-integration');

--- a/src/server/views/admin.pug
+++ b/src/server/views/admin.pug
@@ -6,6 +6,7 @@ html
             #svg-source {
                 display: none;
             }
+        meta(name='viewport',  content='width=device-width, initial-scale=1')
         link(rel='icon', href='/favicon.ico')
         link(href='//fonts.googleapis.com/css?family=Roboto', rel="stylesheet")
         link(rel="stylesheet", href="/fontawesome-free/css/all.min.css")

--- a/src/static/components/HeaderNav.svelte
+++ b/src/static/components/HeaderNav.svelte
@@ -12,7 +12,6 @@
                         class:active={link.app === $activeApp}
                         href={link.path}
                     >
-                        <Icon icon={link.icon} />
                         {link.text}
                     </a>
                 </li>
@@ -22,7 +21,6 @@
 </nav>
 
 <script>
-    import {Icon} from 'sheodox-ui';
     import {activeApp} from "./stores/routing";
     import page from 'page';
 
@@ -32,6 +30,12 @@
         app: 'home',
         text: 'Home',
         icon: 'home'
+    }, {
+        viewable: window.Booker.events.view,
+        path: '/events',
+        app: 'events',
+        text: 'Events',
+        icon: 'calendar-week'
     }, {
         viewable: window.Booker.echo.view,
         path: '/echo',

--- a/src/static/components/HomePage.svelte
+++ b/src/static/components/HomePage.svelte
@@ -6,6 +6,11 @@
 </style>
 
 <div class="page-content f-row f-wrap justify-content-center">
+    {#if window.Booker.events.view}
+        <div class="app-preview">
+            <EventsAppPreview />
+        </div>
+    {/if}
     {#if window.Booker.echo.view}
         <div class="app-preview">
             <RecentUploads />
@@ -22,6 +27,7 @@
     import RecentUploads from "./echo/RecentUploads.svelte";
     import VoterPreview from "./voter/VoterPreview.svelte";
     import {pageName} from "./stores/app";
+    import EventsAppPreview from "./events/EventsAppPreview.svelte";
 
     // clear old page names
     $pageName = '';

--- a/src/static/components/Routing.svelte
+++ b/src/static/components/Routing.svelte
@@ -1,16 +1,24 @@
-{#if $activeRoute === 'echo' && echoView}
+{#if $activeRoute === 'echo' && echo.view}
     <Echo />
-{:else if $activeRoute === 'echo/upload' && echoView}
+{:else if $activeRoute === 'echo/upload' && echo.view && echo.upload}
     <EchoUpload mode="upload" />
-{:else if $activeRoute === 'echo/edit' && echoView}
+{:else if $activeRoute === 'echo/edit' && echo.view && echo.update}
     <EchoUpload mode="edit" />
-{:else if $activeRoute === 'echo/view' && echoView}
+{:else if $activeRoute === 'echo/view' && echo.view}
     <EchoView />
-{:else if $activeRoute === 'voter' && voterView}
+{:else if $activeRoute === 'voter' && voter.view}
     <Voter />
-{:else if $activeRoute === 'voter/race' && voterView}
+{:else if $activeRoute === 'voter/race' && voter.view}
     <VoterRace />
-{:else if !voterView && !echoView}
+{:else if $activeRoute === 'events' && events.view}
+    <Events />
+{:else if $activeRoute === 'events/create' && events.view && events.organize}
+    <EventsEdit mode="create" />
+{:else if $activeRoute === 'events/edit' && events.view && events.organize}
+    <EventsEdit mode="edit" />
+{:else if $activeRoute === 'events/view' && events.view}
+    <EventView />
+{:else if !echo.view && !voter.view && !events.view}
     <NoAccess />
 {:else}
     <HomePage />
@@ -22,9 +30,14 @@
     import EchoView from "./echo/EchoView.svelte";
     import Voter from "./voter/Voter.svelte";
     import VoterRace from "./voter/VoterRace.svelte";
+    import Events from "./events/Events.svelte";
+    import EventsEdit from "./events/EventsEdit.svelte";
     import NoAccess from "./NoAccess.svelte";
     import HomePage from "./HomePage.svelte";
+    import EventView from "./events/EventView.svelte";
 
-    const echoView = window.Booker.echo.view,
-        voterView = window.Booker.echo.view;
+    //shortcuts to permissions!
+    const echo = window.Booker.echo,
+        voter = window.Booker.voter,
+        events = window.Booker.events;
 </script>

--- a/src/static/components/echo/Echo.svelte
+++ b/src/static/components/echo/Echo.svelte
@@ -18,9 +18,6 @@
     h1 {
         margin: 0;
     }
-    .view-modes [aria-pressed="true"] {
-        color: var(--accent-pink);
-    }
 </style>
 
 <div class="f-column f-1 align-items-center">
@@ -74,11 +71,11 @@
                 {/if}
                 <div class="f-row justify-content-end view-modes">
                     <button class="small" on:click={() => view = 'list'} aria-pressed={view === 'list'}>
-                        <Icon icon="list" />
+                        <Icon icon="list" noPadding={true} />
                         <span class="sr-only">View as a list</span>
                     </button>
                     <button class="small" on:click={() => view = 'grid'} aria-pressed={view === 'grid'}>
-                        <Icon icon="th" />
+                        <Icon icon="th" noPadding={true} />
                         <span class="sr-only">View as a grid</span>
                     </button>
                 </div>

--- a/src/static/components/events/Attendance.svelte
+++ b/src/static/components/events/Attendance.svelte
@@ -1,0 +1,55 @@
+<style>
+    h2 {
+        margin: 0;
+    }
+</style>
+
+<div class="attendees">
+    <div class="f-row justify-content-between align-items-center">
+        <h2>RSVPs</h2>
+        {#if rsvps.length && event.eventDays.length > 1}
+            <button on:click={() => showDetails = true}>
+                Details
+            </button>
+        {/if}
+    </div>
+    {#if rsvps.length}
+        <div class="f-row f-wrap">
+            <Attendees rsvps={going} title="Going" />
+            <Attendees rsvps={maybe} title="Maybe" />
+            <Attendees rsvps={notGoing} title="Not Going" />
+        </div>
+    {:else}
+        <p><em>Nobody has responded yet.</em></p>
+    {/if}
+</div>
+
+{#if showDetails}
+    <Modal bind:visible={showDetails} title="Attendee Details">
+        <AttendeeDetails {event} />
+    </Modal>
+{/if}
+
+<script>
+    import {Modal} from 'sheodox-ui';
+    import Attendees from "./Attendees.svelte";
+    import AttendeeDetails from "./AttendeeDetails.svelte";
+
+    export let event;
+
+    let showDetails = false;
+
+    function byStatus(status) {
+        return rsvp => {
+            return rsvp.status === status;
+        }
+    }
+
+    $: rsvps = event.rsvps
+    $: days = event.attendeesByDay
+    $: going = event.rsvps.filter(byStatus('going'));
+    $: notGoing = event.rsvps.filter(byStatus('not-going'));
+    $: maybe = event.rsvps.filter(byStatus('maybe'));
+    $: showDayBreakdown = days.length > 1 && going.length
+
+</script>

--- a/src/static/components/events/AttendanceTypeBadge.svelte
+++ b/src/static/components/events/AttendanceTypeBadge.svelte
@@ -1,0 +1,28 @@
+<style>
+    .attendance-type {
+        font-weight: bold;
+    }
+</style>
+<span class="attendance-type" title={showText ? '' : matchingType.text}>
+    <Icon icon={matchingType.icon} />
+    {#if showText}
+        {matchingType.text}
+    {:else}
+        <span class="sr-only">
+            {matchingType.text}
+        </span>
+    {/if}
+</span>
+
+<script>
+    import {Icon} from 'sheodox-ui';
+    export let event;
+    export let showText;
+
+    const types = {
+        virtual: {icon: 'globe', text: 'Virtual'},
+        real: {icon: 'map-marked-alt', text: 'In Person'}
+    };
+
+    $: matchingType = types[event.attendanceType];
+</script>

--- a/src/static/components/events/AttendeeDetails.svelte
+++ b/src/static/components/events/AttendeeDetails.svelte
@@ -1,0 +1,46 @@
+<div class="modal-body">
+    <TabList {tabs} bind:selectedTab />
+    <Tab {selectedTab} tabId="day-breakdown">
+        <div class="f-row f-wrap">
+            {#each event.attendeesByDay as day}
+                <Attendees rsvps={day.attendees} showEmpty={true}>
+                    {getDayOfWeekName(day.dayOfWeek)} {day.date}
+                </Attendees>
+            {/each}
+        </div>
+    </Tab>
+    <Tab {selectedTab} tabId="overnight">
+        <div class="f-row f-wrap">
+            {#each event.attendeesByDay as day}
+                <Attendees rsvps={day.attendees.filter(rsvp => rsvp.stayingOvernight)} showEmpty={true}>
+                    {getDayOfWeekName(day.dayOfWeek)} {day.date}
+                </Attendees>
+            {/each}
+        </div>
+    </Tab>
+</div>
+
+<script>
+    import {getDayOfWeekName} from "../stores/events";
+    import Attendees from "./Attendees.svelte";
+    import {Tab, TabList} from 'sheodox-ui'
+    export let event;
+
+    $: tabs = createTabs(event);
+    let selectedTab;
+
+    function createTabs(event) {
+        const hasMultipleDays = event.eventDays.length > 1,
+            baseTabs = [{
+                id: 'overnight',
+                title: 'Overnight Guests'
+            }];
+
+        return !hasMultipleDays
+            ? baseTabs
+            : [{
+                id: 'day-breakdown',
+                title: 'Day Breakdown'
+            }, ...baseTabs];
+    }
+</script>

--- a/src/static/components/events/Attendees.svelte
+++ b/src/static/components/events/Attendees.svelte
@@ -1,0 +1,39 @@
+<style>
+    .attendee-list {
+        margin: 0.2rem;
+        max-width: 15rem;
+        padding: 0.5rem;
+    }
+    .user {
+        margin: 0.2rem;
+    }
+    h3 {
+        margin: 0;
+    }
+</style>
+
+{#if rsvps.length || showEmpty}
+    <div class="attendee-list sub-panel">
+        <h3>{title}<slot /></h3>
+        {#if rsvps.length}
+            <small>{rsvps.length} {rsvps.length === 1 ? 'person' : 'people'}</small>
+        {/if}
+        <div>
+            {#each rsvps as rsvp}
+                <div class="user">
+                    <UserBubble user={rsvp.user} />
+                </div>
+            {:else}
+                <p class="text-align-center"><em>No RSPVs.</em></p>
+            {/each}
+        </div>
+    </div>
+{/if}
+
+<script>
+    import UserBubble from '../UserBubble.svelte';
+
+    export let title = '';
+    export let rsvps = [];
+    export let showEmpty = false; //render even if there are no RSVPS to show, will show a "blank" message
+</script>

--- a/src/static/components/events/DateTimeInput.svelte
+++ b/src/static/components/events/DateTimeInput.svelte
@@ -1,0 +1,63 @@
+<style>
+</style>
+
+<div class="f-column">
+    <fieldset>
+        <legend>{label}</legend>
+
+        <label>
+            Date
+            <br>
+            <input type="date" bind:value={dateValue} />
+        </label>
+        <br>
+        <label>
+            Time
+            <br>
+            <input type="time" bind:value={timeValue} />
+        </label>
+    </fieldset>
+</div>
+
+<script>
+    export let date;
+    export let label;
+
+    let dateValue = getInitialDate(),
+        timeValue = getInitialTime();
+
+    function doubleDigitPadded(number) {
+        return (number + '').padStart(2, '0');
+    }
+    function getInitialDate() {
+        if (date) {
+            return [
+                date.getFullYear(),
+                doubleDigitPadded(date.getMonth() + 1),
+                doubleDigitPadded(date.getDate())
+            ].join('-');
+        }
+        return '';
+    }
+
+    function getInitialTime() {
+        if (date) {
+            return [
+                doubleDigitPadded(date.getHours()),
+                doubleDigitPadded(date.getMinutes())
+            ].join(':')
+        }
+        return '';
+    }
+
+    $: date = parseDate(dateValue, timeValue);
+
+    function parseDate(dateString, timeString) {
+        const [years, months, days] = dateString.split('-'),
+            [hours, minutes] = timeString.split(':');
+
+        const possiblyInvalidDate = new Date(years, months - 1, days, hours, minutes);
+
+        return isNaN(possiblyInvalidDate.getTime()) ? null : possiblyInvalidDate;
+    }
+</script>

--- a/src/static/components/events/EventPreview.svelte
+++ b/src/static/components/events/EventPreview.svelte
@@ -1,0 +1,43 @@
+<style>
+    .event {
+
+    }
+</style>
+
+<div class="event sub-panel">
+    <div class="f-row justify-content-between">
+        <Link href="/events/{event.id}">
+            <span>
+                <AttendanceTypeBadge {event} />
+                {event.name}
+            </span>
+        </Link>
+        <span title="{attendees} {attendees === 1 ? 'person' : 'people'} going">
+            <Icon icon="user-friends" /> {attendees} <span class="sr-only">People Going</span>
+        </span>
+    </div>
+
+    <EventTimes {event} />
+
+    <div class="f-row justify-content-end">
+        {#if event.userRsvp}
+            <span>
+                <RSVPStatus status={event.userRsvp?.status} />
+            </span>
+        {/if}
+    </div>
+</div>
+
+<script>
+    import {Icon} from 'sheodox-ui';
+    import Link from "../Link.svelte";
+    import AttendanceTypeBadge from "./AttendanceTypeBadge.svelte";
+    import EventTimes from "./EventTimes.svelte";
+    import RSVPStatus from "./RSVPStatus.svelte";
+
+    export let event;
+
+    $: start = event.startDate.toLocaleString();
+    $: end = event.endDate.toLocaleString();
+    $: attendees = event.rsvps.filter(({status}) => status === 'going').length;
+</script>

--- a/src/static/components/events/EventTimes.svelte
+++ b/src/static/components/events/EventTimes.svelte
@@ -1,0 +1,25 @@
+<style>
+</style>
+
+<p>
+    {#if event.eventDays.length === 1}
+        On {event.startDate.toLocaleDateString()} from {prettyTime(event.startDate)} to {prettyTime(event.endDate)}
+    {:else}
+        From {prettyDate(event.startDate)} to {prettyDate(event.endDate)}
+    {/if}
+</p>
+
+<script>
+    export let event;
+
+    const dateFormat = new Intl.DateTimeFormat('en-US', {dateStyle: 'short', timeStyle: 'short'}),
+        timeFormat = new Intl.DateTimeFormat('en-US', {timeStyle: 'short'});
+
+    function prettyDate(date) {
+        return dateFormat.format(date);
+    }
+
+    function prettyTime(date) {
+        return timeFormat.format(date);
+    }
+</script>

--- a/src/static/components/events/EventView.svelte
+++ b/src/static/components/events/EventView.svelte
@@ -1,0 +1,133 @@
+<style>
+    .sub-panel {
+        margin: 0.5rem;
+    }
+    .details {
+        flex-basis: 30rem;
+    }
+</style>
+
+{#if !$eventsInitialized}
+    <PageSpinner />
+{:else if !$eventFromRoute}
+    <p>Couldn't find an event for this ID, did it get deleted?</p>
+    <p><Link href="/events">Back to the events list.</Link></p>
+{:else}
+    <div class="page-content">
+        <div class="f-row justify-content-between align-items-center">
+            <h1>{$eventFromRoute.name}</h1>
+            {#if window.Booker.events.organize}
+                <MenuButton>
+                <span slot="trigger">
+                    Options
+                    <Icon icon="chevron-down" />
+                </span>
+                    <ul slot="menu">
+                        <li>
+                            <button on:click={() => page(`/events/${$eventFromRoute.id}/edit`)}>
+                                <Icon icon="edit" />
+                                Edit
+                            </button>
+                        </li>
+                        <li>
+                            <button on:click={() => showDeleteConfirm = true}>
+                                <Icon icon="trash" />
+                                Delete
+                            </button>
+                        </li>
+                    </ul>
+                </MenuButton>
+            {/if}
+        </div>
+
+        <div class="f-row f-wrap justify-content-center align-items-start">
+            <div class="f-1">
+                <div class="sub-panel details">
+                    <div class="f-row justify-content-between align-items-start f-wrap">
+                        <div>
+                            <p>
+                                <AttendanceTypeBadge event={$eventFromRoute} showText={true} />
+                            </p>
+                            <EventTimes event={$eventFromRoute} />
+                        </div>
+
+                        {#if window.Booker.events.rsvp}
+                            <RSVP
+                                highlight={pendingStatus}
+                                status={userRsvp?.status}
+                                showFixGoingWarning={userGoing && isMultipleDays && !userRsvp?.rsvpDays.length}
+                                on:rsvp={rsvpPrompt}
+                            />
+                        {/if}
+                    </div>
+
+                    <div class="notes">
+                        {@html $eventFromRoute.notesRendered}
+                    </div>
+                </div>
+                <div class="f-row f-wrap justify-content-between">
+                    {#if window.Booker.events.organize}
+                        <RSVPNotes rsvps={$eventFromRoute.rsvps} />
+                    {/if}
+                </div>
+            </div>
+            <div class="sub-panel">
+                <Attendees event={$eventFromRoute} />
+            </div>
+        </div>
+
+    </div>
+{/if}
+
+{#if showSurvey}
+    <Modal bind:visible={showSurvey} title="RSVP Options" on:closed={() => pendingStatus = null}>
+        <RSVPSurvey bind:pendingStatus bind:visible={showSurvey} />
+    </Modal>
+{/if}
+{#if showDeleteConfirm}
+    <Modal bind:visible={showDeleteConfirm} title="Delete Event">
+        <div class="modal-body">
+            Are you sure you want to delete the event "{$eventFromRoute.name}"?
+        </div>
+        <div class="modal-footer">
+            <button on:click={() => showDeleteConfirm = false}>
+                Cancel
+            </button>
+            <button on:click={deleteEvent} class="danger">
+                <Icon icon="trash" />
+                Delete
+            </button>
+        </div>
+    </Modal>
+{/if}
+
+<script>
+    import {MenuButton, Icon, Modal} from 'sheodox-ui';
+    import PageSpinner from "../PageSpinner.svelte";
+    import {eventFromRoute, eventOps, eventsInitialized} from "../stores/events";
+    import page from 'page';
+    import Link from "../Link.svelte";
+    import RSVP from "./RSVP.svelte";
+    import RSVPSurvey from "./RSVPSurvey.svelte";
+    import AttendanceTypeBadge from "./AttendanceTypeBadge.svelte";
+    import Attendees from "./Attendance.svelte";
+    import EventTimes from "./EventTimes.svelte";
+    import RSVPNotes from "./RSVPNotes.svelte";
+
+    let pendingStatus,
+        showDeleteConfirm = false,
+        showSurvey = false;
+
+    $: userRsvp = $eventFromRoute?.userRsvp
+    $: isMultipleDays = $eventFromRoute?.eventDays.length > 1
+    $: userGoing = userRsvp?.status === 'going'
+
+    function rsvpPrompt(e) {
+        pendingStatus = e.detail;
+        showSurvey = true;
+    }
+
+    function deleteEvent() {
+        eventOps.deleteEvent($eventFromRoute.id);
+    }
+</script>

--- a/src/static/components/events/Events.svelte
+++ b/src/static/components/events/Events.svelte
@@ -1,0 +1,50 @@
+<style>
+
+</style>
+
+{#if !$eventsInitialized}
+    <PageSpinner />
+{:else}
+    <div class="page-contents">
+        <div class="f-row justify-content-between align-items-center">
+            <h1>Events</h1>
+            <Link href="/events/create">
+            <span class="button">
+                <Icon icon="plus" />
+                Create Event
+            </span>
+            </Link>
+        </div>
+
+        {#if $ongoingEvents.length}
+            <h2>Ongoing</h2>
+            {#each $ongoingEvents as event}
+                <EventPreview {event} showRSVP={true} />
+            {/each}
+        {/if}
+        {#if $upcomingEvents.length}
+            <h2>Upcoming</h2>
+            {#each $upcomingEvents as event}
+                <EventPreview {event} showRSVP={true} />
+            {/each}
+        {/if}
+        {#if $pastEvents.length}
+            <h2>Past</h2>
+            {#each $pastEvents as event}
+                <EventPreview {event} />
+            {/each}
+        {/if}
+
+        {#if $events.length === 0}
+            <p>There aren't any events yet.</p>
+        {/if}
+    </div>
+{/if}
+
+<script>
+    import {Icon} from 'sheodox-ui';
+    import Link from "../Link.svelte";
+    import {eventsInitialized, events, ongoingEvents, upcomingEvents, pastEvents} from "../stores/events";
+    import EventPreview from "./EventPreview.svelte";
+    import PageSpinner from "../PageSpinner.svelte";
+</script>

--- a/src/static/components/events/EventsAppPreview.svelte
+++ b/src/static/components/events/EventsAppPreview.svelte
@@ -1,0 +1,56 @@
+<style>
+    h1 {
+        margin: 0 1rem 0 0;
+    }
+</style>
+
+<div>
+    <div class="f-row justify-content-center align-items-center">
+        <h1>{eventTitle}</h1>
+        <Link href="/events">
+            <span class="fw-bold">
+                Check out Events
+                <Icon icon="chevron-right" />
+            </span>
+        </Link>
+    </div>
+    {#if $eventsInitialized}
+        {#if mostRelevantEvent}
+            <EventPreview event={mostRelevantEvent} />
+        {:else}
+            <p class="text-align-center"><em>No events.</em></p>
+        {/if}
+    {:else}
+        <div class="text-align-center">
+            <SpikeSpinner size="medium" />
+        </div>
+    {/if}
+</div>
+
+<script>
+    import {Icon} from 'sheodox-ui';
+    import {ongoingEvents, upcomingEvents, eventsInitialized, pastEvents} from "../stores/events";
+    import EventPreview from "./EventPreview.svelte";
+    import SpikeSpinner from "../SpikeSpinner.svelte";
+    import Link from "../Link.svelte";
+
+    let eventTitle = 'Events',
+        mostRelevantEvent;
+
+    $: findRelevantEvent($ongoingEvents, $upcomingEvents, $pastEvents);
+
+    function findRelevantEvent(ongoing, upcoming, past) {
+        if (ongoing.length) {
+            mostRelevantEvent = ongoing[0];
+            eventTitle = 'Ongoing Event'
+        }
+        else if (upcoming.length) {
+            mostRelevantEvent = upcoming[0];
+            eventTitle = 'Upcoming Event'
+        }
+        else if (past.length) {
+            mostRelevantEvent = past[0];
+            eventTitle = 'Past Event'
+        }
+    }
+</script>

--- a/src/static/components/events/EventsEdit.svelte
+++ b/src/static/components/events/EventsEdit.svelte
@@ -1,0 +1,130 @@
+<style>
+    .page-content {
+        max-width: 50rem;
+    }
+    textarea {
+        width: 100%;
+        height: 10rem;
+        font-size: 0.9rem;
+        resize: vertical;
+    }
+    form :global(fieldset) {
+        border: none;
+    }
+    form :global(legend) {
+        font-size: 1.2rem;
+    }
+</style>
+
+{#if mode === 'create' || $eventFromRoute}
+    <div class="page-content">
+        <h1>{name || 'New Event'}</h1>
+
+        <form on:submit|preventDefault={submit}>
+            <label>
+                Event Name
+                <br />
+                <input bind:value={name} required />
+            </label>
+
+            <div class="f-row">
+                <fieldset>
+                    <legend>Attendance Type</legend>
+
+                    <label>
+                        <input bind:group={attendanceType} value="real" type="radio" />
+                        In person
+                    </label>
+                    <br>
+                    <label>
+                        <input bind:group={attendanceType} value="virtual" type="radio" />
+                        Virtual
+                    </label>
+                </fieldset>
+
+                <DateTimeInput label="Start" bind:date={startDate} />
+                <DateTimeInput label="End" bind:date={endDate} />
+            </div>
+            <br>
+            <label>
+                Details
+                <br>
+                <textarea bind:value={notes}></textarea>
+            </label>
+
+            <small><Icon icon="info-circle" /> Details can use markdown!</small>
+
+            <div class="f-row justify-content-end">
+                {#if mode === 'edit'}
+                    <Link href="/events/{$eventFromRoute.id}">
+                        <span class="button">
+                            <Icon icon="chevron-left" />
+                            Back
+                        </span>
+                    </Link>
+                {/if}
+                <button>{mode === 'create' ? 'Create' : 'Update'} Event</button>
+            </div>
+        </form>
+    </div>
+{:else}
+    <PageSpinner />
+{/if}
+
+<script>
+    import {createAutoExpireToast, Icon} from 'sheodox-ui';
+    import DateTimeInput from "./DateTimeInput.svelte";
+    import {eventFromRoute, eventOps} from "../stores/events";
+    import PageSpinner from "../PageSpinner.svelte";
+    import Link from "../Link.svelte";
+
+    export let mode; // create | edit
+    let name, startDate, endDate, notes,
+        attendanceType = 'real';
+
+    $: initializeData($eventFromRoute)
+
+    let dataInitialized = false;
+
+    function initializeData(event) {
+        if (!dataInitialized && event) {
+            dataInitialized = true;
+            name = event.name;
+            notes = event.notes;
+            startDate = event.startDate;
+            endDate = event.endDate;
+            attendanceType = event.attendanceType;
+        }
+    }
+
+    function validationToast(message) {
+        createAutoExpireToast({
+            variant: 'error',
+            title: 'Error',
+            message
+        })
+    }
+
+    function submit() {
+        if (!startDate) {
+            return validationToast('Enter a start date and time!');
+        }
+        if (!endDate) {
+            return validationToast('Enter an end date and time!');
+        }
+
+        const eventData = {
+            name,
+            notes,
+            attendanceType,
+            startDate: startDate.getTime(),
+            endDate: endDate.getTime(),
+        };
+
+        if (mode === 'create') {
+            eventOps.createEvent(eventData);
+        } else {
+            eventOps.updateEvent($eventFromRoute.id, eventData);
+        }
+    }
+</script>

--- a/src/static/components/events/RSVP.svelte
+++ b/src/static/components/events/RSVP.svelte
@@ -1,0 +1,59 @@
+<style>
+    button[aria-pressed="true"] {
+        border: 1px solid currentColor;
+    }
+    .going[aria-pressed="true"] {
+        background-color: #20ff0021;
+        color: #20ff00
+    }
+    .going[aria-pressed="true"].warning {
+        background-color: #ffff0021;
+        color: #ff0;
+    }
+    .not-going[aria-pressed="true"] {
+        background-color: #ff000021;
+        color: #ff0000
+    }
+    .maybe[aria-pressed="true"] {
+        background-color: #f4f4f421;
+        color: #f4f4f4
+    }
+    .warning {
+        color: yellow;
+        font-style: italic;
+    }
+</style>
+
+<div class="f-row justify-content-center">
+    {#each statusOptions as statusOption}
+        <button
+            class="{statusOption}"
+            class:warning={statusOption  === 'going' && showFixGoingWarning}
+            class:muted={highlight && highlight !== statusOption}
+            aria-pressed={statusOption === status}
+            on:click={() => rsvp(statusOption)}
+        >
+            <RSVPStatus status={statusOption} />
+        </button>
+    {/each}
+</div>
+{#if showFixGoingWarning}
+    <p class="warning">
+        You previously RSVP'd as going but the event is now held over multiple days. Please click "Going" again and select the days you're planning to attend!
+    </p>
+{/if}
+
+<script>
+    import {createEventDispatcher} from 'svelte'
+    import RSVPStatus from "./RSVPStatus.svelte";
+    const dispatch = createEventDispatcher(),
+        statusOptions = ['going', 'maybe', 'not-going'];
+
+    export let status;
+    export let highlight;
+    export let showFixGoingWarning;
+
+    function rsvp(newStatus) {
+        dispatch('rsvp', newStatus);
+    }
+</script>

--- a/src/static/components/events/RSVPNotes.svelte
+++ b/src/static/components/events/RSVPNotes.svelte
@@ -1,0 +1,39 @@
+<style>
+    .rsvp-notes {
+        max-width: 15rem;
+        margin: 0.2rem;
+    }
+</style>
+
+{#if rsvps.length}
+    <div>
+        <h2>Notes for the organizer</h2>
+        <div class="f-row f-wrap">
+            {#each rsvps as rsvp}
+                {#if rsvp.notes}
+                    <div class="rsvp-notes sub-panel">
+                        <div>
+                            <UserBubble user={rsvp.user}>
+                                <span>
+                                    <RSVPStatus status={rsvp.status} />
+                                </span>
+                            </UserBubble>
+                        </div>
+                        <p>{rsvp.notes}</p>
+                    </div>
+                {/if}
+            {/each}
+            {#if !hasNotes}
+                <p><em>Nobody left any notes.</em></p>
+            {/if}
+        </div>
+    </div>
+{/if}
+
+<script>
+    import UserBubble from "../UserBubble.svelte";
+    import RSVPStatus from "./RSVPStatus.svelte";
+
+    export let rsvps;
+    $: hasNotes = rsvps.some(({notes}) => !!notes)
+</script>

--- a/src/static/components/events/RSVPStatus.svelte
+++ b/src/static/components/events/RSVPStatus.svelte
@@ -1,0 +1,16 @@
+{#if status === 'going'}
+    <Icon icon="calendar-check" />
+    Going
+{:else if status === 'not-going'}
+    <Icon icon="calendar-times" />
+    Not Going
+{:else if status === 'maybe'}
+    <Icon icon="question" />
+    Maybe
+{/if}
+
+<script>
+    import {Icon} from 'sheodox-ui';
+
+    export let status;
+</script>

--- a/src/static/components/events/RSVPSurvey.svelte
+++ b/src/static/components/events/RSVPSurvey.svelte
@@ -1,0 +1,122 @@
+<style>
+    .eventDay {
+        margin: 0.2rem;
+        padding: 0.5rem;
+        border: 1px solid transparent;
+        border-radius: 3px;
+        transition: border-color 0.2s, background 0.2s;
+    }
+    .eventDay.going {
+        border-color: var(--accent-blue);
+        background: var(--accent-blue-dark);
+    }
+    fieldset {
+        border: none;
+    }
+    textarea {
+        width: 30rem;
+        height: 6rem;
+        max-width: 90vw;
+        resize: vertical;
+    }
+    .disabled {
+        opacity: 0;
+    }
+</style>
+
+<div class="modal-body">
+    {#if days.length > 1 && pendingStatus === 'going'}
+        <p>Which days are you attending?</p>
+        <div class="f-row f-wrap">
+            {#each days as day, index}
+                <div class="eventDay" class:going={day.going}>
+                    <fieldset>
+                        <legend><strong>{getDayOfWeekName(day.dayOfWeek)}</strong> {day.date}</legend>
+                        <label>
+                            <input bind:checked={day.going} type="checkbox"/>
+                            Going
+                        </label>
+                        <br>
+                        {#if $eventFromRoute.attendanceType === 'real' && index !== days.length - 1}
+                            <label class:disabled={!day.going}>
+                                <input bind:checked={day.stayingOvernight} type="checkbox" disabled={!day.going} />
+                                Staying overnight
+                            </label>
+                        {/if}
+                    </fieldset>
+                </div>
+            {/each}
+        </div>
+    {/if}
+    <div>
+        <label>
+            Notes for the organizer
+            <br>
+            <textarea
+                bind:value={notes}
+                placeholder="{getNotesPlaceholder(pendingStatus, $eventFromRoute.attendanceType)} Anything you think the organizer should know."
+            ></textarea>
+        </label>
+    </div>
+    <div class="modal-footer">
+        <button disabled={!submittable} on:click={rsvp}>RSVP as {statusName}</button>
+    </div>
+</div>
+
+<script>
+    import {eventFromRoute, eventOps, getDayOfWeekName} from "../stores/events";
+
+    export let pendingStatus;
+    export let visible;
+
+    const previousResponse = $eventFromRoute.userRsvp,
+        baseEventDays = JSON.parse(JSON.stringify($eventFromRoute.eventDays)).map(dayInfo => {
+            return {
+                ...dayInfo,
+                going: false,
+                stayingOvernight: false
+            }
+        }),
+        days = mergeMissingDays(previousResponse?.rsvpDays, baseEventDays);
+
+    let notes = previousResponse?.notes ?? '';
+
+    //if the event is one day only, we assume they're going the single day if they RSVP as going, so we don't show rsvp days
+    $: goingSomeDay = days.length === 1 || days.some(day => day.going);
+    $: submittable = pendingStatus !== 'going' || goingSomeDay;
+    $: statusName = {going: 'Going', 'not-going': 'Not Going', maybe: 'Maybe'}[pendingStatus];
+
+    function mergeMissingDays(rsvpDays, baseEventDays) {
+        if (!rsvpDays) {
+            return baseEventDays;
+        }
+        return baseEventDays.map(baseDay => {
+            const existingRsvp = rsvpDays.find(day => day.date === baseDay.date);
+            if (existingRsvp) {
+                return {
+                    ...baseDay,
+                    ...existingRsvp,
+                    going: true
+                }
+            }
+            return baseDay;
+        })
+    }
+
+    function getNotesPlaceholder(status, attendanceType) {
+        if (status === 'going') {
+            attendanceType === 'virtual' ?
+                `Times you're not available during the event, requests, etc.` :
+                'Arrival times, special accommodations needed, food/games you plan to bring bring, etc.';
+        }
+        return '';
+    }
+    function rsvp() {
+        eventOps.rsvp($eventFromRoute.id, pendingStatus, {
+            days,
+            notes
+        })
+        pendingStatus = null;
+        visible = false;
+    }
+</script>

--- a/src/static/components/stores/events.js
+++ b/src/static/components/stores/events.js
@@ -1,0 +1,96 @@
+import {writable, derived, get} from "svelte/store";
+import {socket} from "../../socket";
+import page from 'page';
+import {Conduit} from "../../../shared/conduit";
+import {activeRouteParams} from "./routing";
+const eventConduit = new Conduit(socket, 'events');
+
+export const eventsInitialized = writable(false);
+export const events = writable([], set => {
+    if (!window.Booker.events.view) {
+        return;
+    }
+
+    if (!get(eventsInitialized)) {
+        eventConduit.emit('init');
+    }
+});
+function sortAsc(events) {
+    events.sort((a, b) => {
+        return a.startDate.getTime() - b.startDate.getTime();
+    });
+    return events;
+}
+function sortDesc(events) {
+    events.sort((a, b) => {
+        return b.startDate.getTime() - a.startDate.getTime();
+    });
+    return events;
+}
+export const ongoingEvents = derived(events, events => {
+    const now = Date.now();
+
+    //ongoing events should show the soonest event first
+    return sortAsc(events.filter(event => {
+        return event.startDate.getTime() < now && now < event.endDate.getTime();
+    }));
+});
+export const upcomingEvents = derived(events, events => {
+    const now = Date.now();
+
+    return sortAsc(events.filter(event => {
+        return now < event.startDate.getTime();
+    }));
+});
+export const pastEvents = derived(events, events => {
+    const now = Date.now();
+
+    return sortDesc(events.filter(event => {
+        return event.endDate.getTime() < now;
+    }));
+});
+export const eventFromRoute = derived([events, activeRouteParams], ([events, routeParams]) => {
+    return events.find(event => {
+        return event.id === routeParams.eventId;
+    })
+})
+
+eventConduit.on({
+    refresh: data => {
+        data.forEach(event => {
+            event.startDate = new Date(event.startDate);
+            event.endDate = new Date(event.endDate);
+        })
+        events.set(data);
+        eventsInitialized.set(true);
+    }
+})
+
+const daysOfTheWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+export function getDayOfWeekName(dayIndex) {
+    return daysOfTheWeek[dayIndex];
+}
+
+export const eventOps = {
+    createEvent: (data) => {
+        eventConduit.emit('createEvent', data, id => {
+            if (id) {
+                page(`/events/${id}`);
+            }
+        })
+    },
+    updateEvent: (id, data) => {
+        eventConduit.emit('updateEvent', id, data, id => {
+            if (id) {
+                page(`/events/${id}`);
+            }
+        })
+    },
+    deleteEvent: (id) => {
+        eventConduit.emit('deleteEvent', id);
+        page('/events')
+    },
+    rsvp: (eventId, rsvpStatus, survey) => {
+        eventConduit.emit('rsvp', eventId, rsvpStatus, survey);
+    }
+}

--- a/src/static/components/stores/routing.js
+++ b/src/static/components/stores/routing.js
@@ -21,6 +21,10 @@ function setRoute(app, routeId) {
     }
 }
 
+page(`/events`, setRoute('events', 'events'))
+page(`/events/create`, setRoute('events', 'events/create'))
+page(`/events/:eventId`, setRoute('events', 'events/view'))
+page(`/events/:eventId/edit`, setRoute('events', 'events/edit'))
 page(`/echo`, setRoute('echo', 'echo'))
 page(`/echo/upload`, setRoute('echo', 'echo/upload'))
 page(`/echo/:echoId`, setRoute('echo', 'echo/view'))


### PR DESCRIPTION
Events uses three tables. An "Events" table for every actual event that's planned, an "RSVP" table for every response to an event, and an "RSVPDay" table that has day-by-day responses to every day an event is held, so a user can RSVP to an event but only plan on attending certain days if the event lasts more than one day.

With events I used a single 'organize' permission instead of separate add/update/delete permissions. Realistically I can't see a situation where someone can update but not delete an item etc.